### PR TITLE
Bump slf4j from 1.7.36 to 2.0.9 in /tests

### DIFF
--- a/tests/pom.xml
+++ b/tests/pom.xml
@@ -10,6 +10,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.release>17</maven.compiler.release>
+        <version.slf4j>2.0.9</version.slf4j>
+        <version.testcontainers>1.19.1</version.testcontainers>
     </properties>
 
     <dependencies>
@@ -24,14 +26,14 @@
         <dependency>
             <artifactId>slf4j-api</artifactId>
             <groupId>org.slf4j</groupId>
-            <version>1.7.36</version>
+            <version>${version.slf4j}</version>
             <scope>test</scope>
         </dependency>
         <!-- make slf4j not complain (configure: -Dorg.slf4j.simpleLogger.defaultLogLevel=info) -->
         <dependency>
             <artifactId>slf4j-simple</artifactId>
             <groupId>org.slf4j</groupId>
-            <version>1.7.36</version>
+            <version>${version.slf4j}</version>
             <scope>test</scope>
         </dependency>
 
@@ -39,24 +41,24 @@
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>testcontainers</artifactId>
-            <version>1.19.1</version>
+            <version>${version.testcontainers}</version>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>oracle-xe</artifactId>
-            <version>1.19.1</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>postgresql</artifactId>
-            <version>1.19.1</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>mssqlserver</artifactId>
-            <version>1.19.1</version>
+            <version>${version.testcontainers}</version>
             <scope>test</scope>
         </dependency>
 


### PR DESCRIPTION
This introduces a version property for testcontainers and slf4j.

Closes #8, #9