### PR TITLE
Bump maven-dependency-submission-action from 3.0.2 to 3.0.3 (#7)

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -31,6 +31,8 @@ jobs:
 
     # Optional: Uploads the full dependency graph to GitHub to improve the quality of Dependabot alerts this repository can receive
     - name: Update dependency graph
-      uses: advanced-security/maven-dependency-submission-action@c5ad0fd6b977364190852883b46728f25a9617c3
+      uses: advanced-security/maven-dependency-submission-action@fcd7eab6b6d22946badc98d1e62665cdee93e0ae
+      # fails with read-only token on PRs, so only run it on main pushes
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
       with:
         directory: tests/


### PR DESCRIPTION
Also fixes the problem that it does not work on pull request branches.

Closes #7