### PR TITLE
Avoid errors in 2025 by reversing the logic

### DIFF
--- a/examples/scheduler/gate.bsh
+++ b/examples/scheduler/gate.bsh
@@ -1,6 +1,6 @@
-/* 
+/*
  * gate.bsh - Sample script for SEEBURGER BIS Scheduler (gate functionality).
- * 
+ *
  * Copyright SEEBURGER AG, Germany. All rights reserved.
  */
 
@@ -47,10 +47,10 @@ import java.util.Objects;
         final ZonedDateTime now = ZonedDateTime.ofInstant(Instant.now(), zoneId);
 
         // sample error condition
-        if (now.getYear() > 2025)
+        if (now.getYear() < 2022)
         {
             // the exception message will be shown in the Scheduler Execution History
-            throw new ScriptException("This script is not ready for the future. year=" + now.getYear() + " > 2025");
+            throw new ScriptException("This script is not ready for the past. year=" + now.getYear() + " < 2022");
         }
 
         // sample skip condition: skip every first friday of month


### PR DESCRIPTION
Only throw an error if we are in the past. This should be enough to showcase the condition and how to produce error without the risk of a permanent error in case someone uses the example as is.