### PR TITLE
maven-verify.yml: allow switching off dependency submission

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Update dependency graph
       uses: advanced-security/maven-dependency-submission-action@73da25169f2ac4d336320399ba58070deebc1208
       # fails with read-only token on PRs, so only run it on main pushes
-      if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
+      # if DISABLE_MAVEN_DEPENDENCY_SUBMISSION is set to true, skip this step
+      if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' && vars.DISABLE_MAVEN_DEPENDENCY_SUBMISSION != 'true' }}
       with:
         directory: tests/


### PR DESCRIPTION
This is because the plugin might break and is not critical for verification builds.