### PR TITLE
code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/maven-verify.yml
+++ b/.github/workflows/maven-verify.yml
@@ -3,6 +3,9 @@
 
 name: "Verify Resources (java-maven CI)"
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "main" ]


### PR DESCRIPTION
Potential fix for [https://github.com/seeburger-ag/bis-resources/security/code-scanning/1](https://github.com/seeburger-ag/bis-resources/security/code-scanning/1)

To address the issue, we will add a `permissions` block at the root level of the workflow file. This block will specify the least privileges required for the workflow to function correctly. Based on the workflow's steps, the minimal permissions required are `contents: read`. This will ensure that the workflow can access the repository contents without granting unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
